### PR TITLE
Test build preview functionality - Add rocket emoji to hero title

### DIFF
--- a/ui/src/pages/Landing.tsx
+++ b/ui/src/pages/Landing.tsx
@@ -240,7 +240,7 @@ export default function Landing() {
                   <span className="text-transparent bg-clip-text bg-gradient-to-r from-green-800 to-green-900">
                     Live Business
                   </span>{" "}
-                  in Hours.
+                  in Hours. 🚀
                 </h1>
                 <p className="text-xl text-stone-700 leading-relaxed">
                   Describe your SaaS idea. Our AI factory builds the app, configures payments, and automates your operations, launching a ready-to-run business on Google Cloud.


### PR DESCRIPTION
   Testing the new build preview feature implemented in Night 14.
   
   This PR should trigger the build-preview workflow which will:
   1. Build the React app
   2. Upload the built files to the GCS staging bucket
   3. Generate a public preview URL
   4. Post the preview URL as a comment on this PR
   
   Expected staging bucket: `ui-staging-builds-summer-nexus-463503-e1`
   Expected build path: `test-build-preview/a294e69`